### PR TITLE
Skeleton for GitLab support

### DIFF
--- a/src/gitLabUser.ts
+++ b/src/gitLabUser.ts
@@ -1,0 +1,9 @@
+export class GitLabUser {
+  id: number;
+  token: string;
+
+  constructor(id: number, token: string) {
+    this.id = id;
+    this.token = token;
+  }
+}

--- a/src/github.ts
+++ b/src/github.ts
@@ -41,8 +41,6 @@ export function resetGitHubCallsCounter() {
 }
 
 /**
- * Returns 2 for grey icon, 1 for red, 0 for yellow, -1 for green..
- *
  * @param repo The repo state will be updated as a result of the call.
  */
 export async function syncGitHubRepo(repo: RepoState, myGitHubUserId: number) {

--- a/src/gitlab.ts
+++ b/src/gitlab.ts
@@ -1,0 +1,23 @@
+import { RepoSyncResult } from "./repoSyncResult";
+import { RepoState } from "./repoState";
+
+export let gitLabCallsCounter = 0;
+
+export function resetGitLabCallsCounter() {
+  gitLabCallsCounter = 0;
+}
+
+/**
+ * @param repo The repo state will be updated as a result of the call.
+ */
+export async function syncGitLabRepo(repo: RepoState, myGitLabUserId: number) {
+  // TODO(29): implement
+  repo.lastSyncResult = new RepoSyncResult(
+    [],
+    [],
+    Date.now(),
+    "GitLab sync not implemented",
+  );
+  // to get rid of warning:
+  console.log("gitLabUserId" + myGitLabUserId);
+}

--- a/src/popup.ts
+++ b/src/popup.ts
@@ -21,13 +21,15 @@ document.getElementById("go-to-options").addEventListener("click", () => {
   chrome.runtime.openOptionsPage();
 });
 
-document.getElementById("tokenForm").addEventListener("submit", (e) => {
+// TODO(29): add exactly the same for GitLab. Either GitHub or GitLab is enough to start working
+// with extension.
+document.getElementById("gitHubTokenForm").addEventListener("submit", (e) => {
   e.preventDefault();
-  const newToken = (
-    document.getElementById("newToken") as HTMLInputElement
+  const newGitHubToken = (
+    document.getElementById("newGitHubToken") as HTMLInputElement
   ).value.trim();
   new Octokit({
-    auth: newToken,
+    auth: newGitHubToken,
   })
     .request("GET /user", {
       headers: {
@@ -37,10 +39,10 @@ document.getElementById("tokenForm").addEventListener("submit", (e) => {
     .then((v) => {
       const userId = v.data.id;
       console.log("GitHub user ID: " + userId);
-      const gitHubUser = new GitHubUser(userId, newToken);
+      const gitHubUser = new GitHubUser(userId, newGitHubToken);
       const result = storeGitHubUser(gitHubUser);
       // trigger sync:
-      trySyncWithCredentials(gitHubUser);
+      trySyncWithCredentials(gitHubUser, undefined);
       return result;
     })
     .then(() => {
@@ -54,6 +56,7 @@ document.getElementById("tokenForm").addEventListener("submit", (e) => {
 
 class NoGitHubToken extends Error {}
 
+// TODO(29): show setup only if no valid GitHub AND no valid GitLab token.
 getGitHubUser()
   .then((gitHubUser) => {
     if (gitHubUser && gitHubUser.token) {
@@ -94,6 +97,7 @@ getGitHubUser()
 
 const BAD_CREDENTIALS_GITHUB_ERROR_MSG = "Bad credentials";
 
+// TODO(29): add similar error processing for GitLab.
 function showError(e: Error) {
   document.getElementById("auth").style.display = "block";
   if (e instanceof NoGitHubToken) {
@@ -123,10 +127,9 @@ async function updatePopupPage() {
   const settings = await getSettings();
   await reposState.updateIcon(repos, notMyTurnBlocks, settings);
 
-  const repoStateByFullName = reposState.repoStateByFullName;
   const syncSuccessRepos = repos
     .filter((r) => {
-      const repoState = repoStateByFullName.get(r.fullName());
+      const repoState = reposState.getState(r);
       if (!repoState) {
         return false;
       }
@@ -138,10 +141,10 @@ async function updatePopupPage() {
             repoState.lastSyncResult.syncStartUnixMillis)
       );
     })
-    .map((r) => repoStateByFullName.get(r.fullName()));
+    .map((r) => reposState.getState(r));
   const syncFailureRepos = repos
     .filter((r) => {
-      const repoState = repoStateByFullName.get(r.fullName());
+      const repoState = reposState.getState(r);
       if (!repoState) {
         return false;
       }
@@ -151,7 +154,7 @@ async function updatePopupPage() {
       // #NOT_MATURE: is the following always true?
       return repoState.lastSyncResult.errorMsg;
     })
-    .map((r) => repoStateByFullName.get(r.fullName()));
+    .map((r) => reposState.getState(r));
   const unsyncedRepos = repos.filter((r) => {
     return (
       !syncSuccessRepos.some((v) => v.fullName === r.fullName()) &&
@@ -230,6 +233,7 @@ async function populateFromState(
     repoWarnSection.innerHTML = "";
   }
 
+  // TODO(29): not sure if it's worth separating GitLab from GitHub repos here, probably it is:
   const minSuccessSyncStartUnixMillis = Math.min(
     ...syncSuccessRepos.map(
       (r) => r.lastSuccessfulSyncResult.syncStartUnixMillis,

--- a/src/repo.ts
+++ b/src/repo.ts
@@ -1,5 +1,6 @@
 export enum RepoType {
   GITHUB,
+  GITLAB,
 }
 
 export class Repo {

--- a/src/repoState.ts
+++ b/src/repoState.ts
@@ -1,19 +1,23 @@
+import { RepoType } from "./repo";
 import { SyncStatus } from "./reposState";
 import { Settings } from "./settings";
 import { NotMyTurnBlock } from "./notMyTurnBlock";
 import { RepoSyncResult } from "./repoSyncResult";
 
 export class RepoState {
+  readonly repoType: RepoType;
   readonly fullName: string;
   lastSyncResult: RepoSyncResult;
   // Undefined if there were no successful syncs.
   lastSuccessfulSyncResult: RepoSyncResult;
 
   constructor(
-    repoFullName: string = undefined,
+    repoType: RepoType,
+    repoFullName: string,
     lastSyncResult: RepoSyncResult = undefined,
     lastSuccessfulSyncResult: RepoSyncResult = undefined,
   ) {
+    this.repoType = repoType;
     this.fullName = repoFullName;
     this.lastSyncResult = lastSyncResult;
     this.lastSuccessfulSyncResult = lastSuccessfulSyncResult;
@@ -50,6 +54,7 @@ export class RepoState {
   // https://stackoverflow.com/questions/34031448/typescript-typeerror-myclass-myfunction-is-not-a-function
   static of(repoState: RepoState): RepoState {
     return new RepoState(
+      repoState.repoType ? repoState.repoType : RepoType.GITHUB,
       repoState.fullName,
       RepoSyncResult.of(repoState.lastSyncResult),
       repoState.lastSuccessfulSyncResult

--- a/src/reposState.ts
+++ b/src/reposState.ts
@@ -16,10 +16,10 @@ export enum SyncStatus {
 }
 
 export class ReposState {
-  repoStateByFullName: Map<string, RepoState>;
+  repoStateList: RepoState[];
 
-  constructor(repoStateByFullName: Map<string, RepoState>) {
-    this.repoStateByFullName = repoStateByFullName;
+  constructor(repoStateList: RepoState[]) {
+    this.repoStateList = repoStateList;
   }
 
   async updateIcon(
@@ -38,7 +38,7 @@ export class ReposState {
     }
     let syncStatus = SyncStatus.Green;
     for (const repo of monitoringEnabledRepos) {
-      const repoState = this.repoStateByFullName.get(repo.fullName());
+      const repoState = this.getState(repo);
       if (!repoState || !repoState.hasRecentSuccessfulSync()) {
         syncStatus = SyncStatus.Grey;
         break;
@@ -66,6 +66,17 @@ export class ReposState {
   }
 
   asArray() {
-    return [...this.repoStateByFullName.values()];
+    return this.repoStateList;
+  }
+
+  getState(repo: Repo) {
+    const matchingRepoStates = this.repoStateList.filter(
+      (v) => v.fullName === repo.fullName() && v.repoType === repo.type,
+    );
+    if (matchingRepoStates.length === 0) {
+      return undefined;
+    }
+    // TODO: assert matchingRepoStates.length === 1
+    return matchingRepoStates[0];
   }
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,5 @@
 import { getBucket } from "@extend-chrome/storage";
+import { GitLabUser } from "./gitLabUser";
 import { ReposState } from "./reposState";
 import { Settings } from "./settings";
 import { GitHubUser } from "./gitHubUser";
@@ -19,14 +20,8 @@ class RepoList {
   }
 }
 
-export async function storeReposMap(
-  reposByFullName: Map<string, Repo>,
-): Promise<RepoList> {
+export async function storeReposList(repos: Repo[]): Promise<RepoList> {
   console.log("Storing repos");
-  const repos = [] as Repo[];
-  reposByFullName.forEach((repo: Repo) => {
-    repos.push(repo);
-  });
   return getBucket<RepoList>(REPO_STORE_KEY, "sync").set(new RepoList(repos));
 }
 
@@ -55,17 +50,6 @@ class RepoStateList {
   }
 }
 
-export async function storeRepoStateMap(
-  repoStateByFullName: Map<string, RepoState>,
-): Promise<RepoStateList> {
-  console.log("Storing repos state");
-  const repoStateList = [] as RepoState[];
-  repoStateByFullName.forEach((repoState: RepoState) => {
-    repoStateList.push(repoState);
-  });
-  return storeRepoStateList(repoStateList);
-}
-
 export async function storeRepoStateList(repoStateList: RepoState[]) {
   return getBucket<RepoStateList>(REPO_STATE_LIST_STORE_KEY, "local").set(
     new RepoStateList(repoStateList),
@@ -73,20 +57,8 @@ export async function storeRepoStateList(repoStateList: RepoState[]) {
 }
 
 export async function getReposState(): Promise<ReposState> {
-  return getRepoStateByFullName().then((repoStateMap) => {
-    return new ReposState(repoStateMap);
-  });
-}
-
-export async function getRepoStateByFullName(): Promise<
-  Map<string, RepoState>
-> {
   return getRepoStateList().then((repoStateList) => {
-    const result = new Map<string, RepoState>();
-    repoStateList.forEach((repoState) =>
-      result.set(repoState.fullName, repoState),
-    );
-    return result;
+    return new ReposState(repoStateList);
   });
 }
 
@@ -115,6 +87,21 @@ export async function storeGitHubUser(user: GitHubUser) {
 
 export async function getGitHubUser(): Promise<GitHubUser> {
   const store = getBucket<GitHubUser>("gitHubUser", "sync");
+  return store.get();
+}
+
+// GitLabUser storage:
+
+export async function storeGitLabUser(user: GitLabUser) {
+  const store = getBucket<GitLabUser>("gitLabUser", "sync");
+  if (!user) {
+    return store.clear();
+  }
+  return store.set(user);
+}
+
+export async function getGitLabUser(): Promise<GitLabUser> {
+  const store = getBucket<GitLabUser>("gitLabUser", "sync");
   return store.get();
 }
 

--- a/static/options.html
+++ b/static/options.html
@@ -12,16 +12,28 @@
 <div class="container">
   <div id="main">
     <h1>Choose GitHub repositories to monitor:</h1>
-    <form id="repoForm">
-      <span id="repoList">
+    <form id="gitHubRepoForm">
+      <span id="gitHubRepoList">
       </span>
       <h1>Add a new GitHub repository:</h1>
-      <label for="newRepo">New repo:</label>
-      <input type="text" id="newRepo" name="newRepo">
+      <label for="newGitHubRepo">New repo:</label>
+      <input type="text" id="newGitHubRepo" name="newGitHubRepo">
       <button type="submit">Add</button>
       <br/>For example, artie-shevchenko/my-turn-pr-review
-      <div id="addRepoSuccess" style="display:none; color:yellow">Success! Sync with GitHub has started. It may take up to several minutes for large repos.<br/>Work with PRs in other repositories? Add them now!</div>
-      <div id="addRepoError" style="color:yellow"></div>
+      <div id="addGitHubRepoSuccess" style="display:none; color:yellow">Success! Sync with GitHub has started. It may take up to several minutes for large repos.<br/>Work with PRs in other repositories? Add them now!</div>
+      <div id="addGitHubRepoError" style="color:yellow"></div>
+    </form>
+    <h1>Choose GitLab repositories to monitor:</h1>
+    <form id="gitLabRepoForm">
+      <span id="gitLabRepoList">
+      </span>
+      <h1>Add a new GitLab repository:</h1>
+      <label for="newGitLabRepo">New repo:</label>
+      <input type="text" id="newGitLabRepo" name="newGitLabRepo">
+      <button type="submit">Add</button>
+      <br/>For example, TODO(29)
+      <div id="addGitLabRepoSuccess" style="display:none; color:yellow">Success! Sync with GitLab has started. It may take up to several minutes for large repos.<br/>Work with PRs in other repositories? Add them now!</div>
+      <div id="addGitLabRepoError" style="color:yellow"></div>
     </form>
     <h1>Settings</h1>
     <div id="incomingReviewsSettings">

--- a/static/popup.html
+++ b/static/popup.html
@@ -15,16 +15,25 @@
     <img src="pin-instructions.png" style="border: 1px solid #555; width: 300px;" alt="Open the Extensions Menu by clicking the puzzle piece icon next to your profile avatar. Then press the Pushpin icon">
     <h2>2. Move the extension icon to the leftmost position</h2>
     <img src="move-icon-left-instructions.png" style="border: 1px solid #555; width: 350px;" alt="Move the extension icon to the leftmost position. Drag-and-drop">
-    <h2>3. Add your GitHub access token</h2>
+    <h2>3. Add your GitHub or GitLab access token</h2>
   </div>
 <div id="auth" style="display:none">
   <div id="error" style="display:none; color: red"></div>
-  <form id="tokenForm">
+  <h3>GitHub</h3>
+  <form id="gitHubTokenForm">
       1. <a href="https://github.com/settings/tokens/new?description=my-turn-pr-review-chrome&scopes=repo,read:project,read:org" target="_blank">Generate a GitHub token with repo, read:org, and read:project scopes</a>.<br/>
       2. If you see the "Configure SSO" select box authorize access to all the necessary organizations:<br/>
       <img src="configure-sso-instructions.png" style="border: 1px solid #555; width: 600px;" alt="Grant access to all the necessary organizations">
       3. Submit token:
-    <input type="text" id="newToken" name=newToken" autocomplete="off">
+    <input type="text" id="newGitHubToken" name=newGitHubToken" autocomplete="off">
+    <button type="submit">Submit</button>
+  </form>
+  <h3>GitLab</h3>
+  <form id="gitLabTokenForm">
+      1. Generate a GitLab token. TODO(29): add a link<br/>
+      2. Configure SSO. TODO(29): add instructions<br/>
+      3. Submit token:
+    <input type="text" id="newGitLabToken" name=newGitLabToken" autocomplete="off">
     <button type="submit">Submit</button>
   </form>
 </div>


### PR DESCRIPTION
Re #29. "GitLab support"

GitLab repos list management is ready as well as all the structural support for GitLab implementation I think.

TODOs for GitLab support MVP:

1. Start with a `gitLabTokenForm` on `popup.html` and create an event handler for it in `popup.ts`. Make sure it's a valid token and store it by calling `storeGitLabUser`.
2. Init GitLab API client in `gitlab.ts`.
3. Implement GitLab repo sync in `gitlab.ts`, similar to `github.ts`. I think we should be able to reuse `MyPR#ofGitHubResponses` without any changes, but if we're not lucky and there are different models what are reviews then might be necessary to tweak it.
4. [p2] Add tokens management to Settings, to make it possible to have sync both with GitHub and GitLab repos.
5. [p2] Design and implement behavior in case there are problems with GitHub token, but not with GitLab.

There are TODO(29) in code, hopefully helpful.